### PR TITLE
Move camera to current location provided by browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ On the other hand, the Pacific Ocean takes half the space and there's nothing th
 	* As in all classical columns have a capital
 	* Country or state flag?
 	* Placards over each bar showing country & cases?
-* Globe rotates to the lat/lon indicated by your browser location
 * Days since last new case indicated as color or opacity
 * Community transmission vs traveller transmission
 	* Data in WHO PDF file hard to parse

--- a/dev/v-2020-03-22-15-15/js/main.js
+++ b/dev/v-2020-03-22-15-15/js/main.js
@@ -80,6 +80,10 @@ function init () {
 	document.addEventListener( 'mousemove', onDocumentMouseMove, false );
 	document.addEventListener( 'touchstart', onDocumentTouchStart, false );
 
+	if ("geolocation" in navigator) {
+		navigator.geolocation.getCurrentPosition(moveCameraToCurrentLocation);
+  	}
+
 }
 
 
@@ -585,6 +589,15 @@ function addSkyBox () {
 
 }
 
+function moveCameraToCurrentLocation ( position ) {
+	controls.autoRotate = false;
+
+	const radius = camera.position.length(); // keep current distance to center
+	let newCameraPosition = latLonToXYZ( radius, position.coords.latitude, position.coords.longitude, null );
+
+	camera.position.copy(newCameraPosition);
+	controls.update();
+}
 
 /////////
 


### PR DESCRIPTION
This PR implements the suggested feature to use the location information provided by the browser to set the camera position.

Right now, the camera is moved as soon as the user grants access to the location service, or during init if the user already granted access previously.